### PR TITLE
Polling support for HTTP client

### DIFF
--- a/chans/httpclient_test.go
+++ b/chans/httpclient_test.go
@@ -1,0 +1,114 @@
+package chans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Comcast/plax/dsl"
+)
+
+// TestHTTPRequestPolling check that a HTTPRequest channel actually
+// makes multiple requests when a PollInterval is given.
+func TestHTTPRequestPolling(t *testing.T) {
+	var (
+		ctx      = dsl.NewCtx(context.Background())
+		interval = 50 * time.Millisecond // PollInterval
+		want     = 3                     // The number of messages we want to receive.
+
+		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, `{"I have fixed your doorbell from the ringing":"There is no charge"}`)
+		}))
+	)
+
+	defer ts.Close()
+
+	c, err := NewHTTPClientChan(ctx, &HTTPClientOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = c.Open(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		if err := c.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	err = c.Pub(ctx, dsl.Msg{
+		Payload: &HTTPRequest{
+			Method: "GET",
+			URL:    ts.URL,
+			HTTPRequestCtl: HTTPRequestCtl{
+				PollInterval: interval.String(),
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		ch = c.Recv(ctx)
+
+		// min is the quickest poll that we'll allow.
+		min = interval - interval/10
+	)
+
+	// Check that we get this many messages from the channel.
+	for i := 0; i < want; i++ {
+		var (
+			to   = time.NewTimer(2 * interval)
+			then = time.Now()
+		)
+		select {
+		case <-ctx.Done():
+			t.Fatal("ctx done")
+		case <-to.C:
+			t.Fatal("timeout")
+		case <-ch:
+			// We got a message.
+			if 0 < i {
+				// All messages after the first one.
+				if elapsed := time.Now().Sub(then); elapsed < min {
+					t.Fatalf("too fast: %v", elapsed)
+				}
+				// The timer in the 'select' will
+				// complain about a slow poll.
+			}
+		}
+	}
+
+	// Check termination. We have a little race in our test, but
+	// hopefully it won't cause trouble.
+
+	err = c.Pub(ctx, dsl.Msg{
+		Payload: &HTTPRequest{
+			Method: "GET",
+			URL:    ts.URL,
+			HTTPRequestCtl: HTTPRequestCtl{
+				Terminate: "last",
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("ctx done")
+	case <-time.NewTimer(2 * interval).C:
+		// Timeout before we received a message: good.
+	case <-ch:
+		t.Fatal("received another request")
+	}
+}

--- a/demos/webdriver.yaml
+++ b/demos/webdriver.yaml
@@ -77,14 +77,17 @@ spec:
                   - 'application/json'
               body:
                 text: "Please send queso."
-        - wait: 1s
         - pub:
             payload:
               url: 'http://localhost:{?!port}/wd/hub/session/{?SID}/element/{?ELEMENT}/text'
+              pollinterval: 300ms
               method: GET
         - recv:
             pattern:
               value: "Please send queso."
+        - pub:
+            payload:
+              terminate: last
         - pub:
             payload:
               url: 'http://localhost:{?!port}/wd/hub/session/{?SID}'

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -299,6 +299,15 @@ following channel types:
 	1. `Form`: Optional map of names to _arrays_ of values.  If you
        specify this property, then `Body` becomes this URL-encoded
        value.
+	   
+	1. `PollInterval`: An optional duration (in [Go
+       syntax](https://golang.org/pkg/time/#ParseDuration)) to have
+       this request repeat on that interval.  You can also specify an
+       `Id`, which you can then use to `Terminate` the polling.  If
+       you don't specify an `Id` along with a `PollInterval`, you can
+       stil do `Terminate: last`, which will always work to terminate
+       the most recent polling HTTP request.  See [this
+       demo](../demos/webdriver.yaml).
 
 As the needs arise, we can add channel types like:
 


### PR DESCRIPTION
Specifying that an HTTP request (via a Plax `pub` operation) should be repeated at some interval is handy for (say) [using `WebDriver`](http://appium.io/docs/en/about-appium/getting-started/) to watch for changes in a mobile app.
