### PR TITLE
Plaxrun updated to allow running a subset of tests in a test suite

### DIFF
--- a/cmd/plaxrun/demos/fullrun.yaml
+++ b/cmd/plaxrun/demos/fullrun.yaml
@@ -71,8 +71,7 @@ groups:
       'MARGIN': 200
     tests:
       - name: demos
-        labels:
-          - selftest
+        labels: "selftest"
 
   wait-no-prompt:
     params:

--- a/cmd/plaxrun/dsl/plax_plugin.go
+++ b/cmd/plaxrun/dsl/plax_plugin.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/Comcast/plax/dsl"
 )
@@ -44,6 +43,8 @@ const (
 	PluginDefPriorityKey = "Priority"
 	// PluginDefLabelsKey of the PluginDef map
 	PluginDefLabelsKey = "Labels"
+	// PluginDefTestsKey of the PluginDef map
+	PluginDefTestsKey = "Tests"
 	// PluginDefLogLevelKey of the PluginDef map
 	PluginDefLogLevelKey = "LogLevels"
 	// PluginDefListKey of the PluginDef map
@@ -71,6 +72,21 @@ func (pd PluginDef) GetPluginDefName() (string, error) {
 	ret, ok := value.(string)
 	if !ok {
 		return "", fmt.Errorf("%s is not a string", PluginDefNameKey)
+	}
+
+	return ret, nil
+}
+
+// GetPluginDefTests returns the list of test to run
+func (pd PluginDef) GetPluginDefTests() ([]string, error) {
+	value, ok := pd[PluginDefTestsKey]
+	if !ok {
+		return []string{}, fmt.Errorf("%s was not provided in the plugin definition", PluginDefTestsKey)
+	}
+
+	ret, ok := value.([]string)
+	if !ok {
+		return []string{}, fmt.Errorf("%s is not a []string", PluginDefTestsKey)
 	}
 
 	return ret, nil
@@ -171,8 +187,8 @@ func (pd PluginDef) GetPluginDefLogLevel() (string, error) {
 	return *ret, nil
 }
 
-// GetPluginDefPriorty returns the Priority
-func (pd PluginDef) GetPluginDefPriorty() (int, error) {
+// GetPluginDefPriority returns the Priority
+func (pd PluginDef) GetPluginDefPriority() (int, error) {
 	value, ok := pd[PluginDefPriorityKey]
 	if !ok {
 		return -1, fmt.Errorf("%s was not provided in the plugin definition", PluginDefPriorityKey)
@@ -193,12 +209,12 @@ func (pd PluginDef) GetPluginDefLabels() (string, error) {
 		return "", fmt.Errorf("%s was not provided in the plugin definition", PluginDefLabelsKey)
 	}
 
-	ret, ok := value.([]string)
+	ret, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("%s is not a []string", PluginDefLabelsKey)
+		return "", fmt.Errorf("%s is not a string", PluginDefLabelsKey)
 	}
 
-	return strings.Join(ret, ","), nil
+	return ret, nil
 }
 
 // GetPluginDefRetry returns the Retry

--- a/cmd/plaxrun/dsl/test_constraints.go
+++ b/cmd/plaxrun/dsl/test_constraints.go
@@ -20,7 +20,7 @@ package dsl
 
 // TestConstraints used to constrain the tests run
 type TestConstraints struct {
-	Labels   []string     `yaml:"labels"`
+	Labels   *string      `yaml:"labels,omitempty"`
 	Priority *int         `yaml:"priority,omitempty"`
 	Retry    int          `yaml:"retry"`
 	Seed     int64        `yaml:"seed"`

--- a/cmd/plaxrun/dsl/test_def.go
+++ b/cmd/plaxrun/dsl/test_def.go
@@ -40,9 +40,10 @@ type TestDefMap map[string]TestDef
 // TestDefRef references a TestDef with its constraints
 type TestDefRef struct {
 	TestConstraints `yaml:",inline"`
-	Name            string
+	Name            string       `yaml:"name"`
 	Params          TestParamMap `yaml:"params"`
 	Guard           *TestGuard   `yaml:"guard,omitempty"`
+	tests           []string     `yaml:"-"`
 }
 
 // TestDefRefList is a list of TestDefRefs
@@ -101,12 +102,18 @@ func (tdr TestDefRef) getTaskFunc(ctx *plaxDsl.Ctx, tr TestRun, name string, bs 
 		priority = *tdr.Priority
 	}
 
+	labels := ""
+	if tdr.Labels != nil {
+		labels = *tdr.Labels
+	}
+
 	def := PluginDef{
 		PluginDefNameKey:     name,
 		PluginDefParamsKey:   bs,
 		PluginDefSeedKey:     tdr.Seed,
 		PluginDefPriorityKey: priority,
-		PluginDefLabelsKey:   tdr.Labels,
+		PluginDefLabelsKey:   labels,
+		PluginDefTestsKey:    tdr.tests,
 		PluginDefRetryKey:    strconv.Itoa(tdr.Retry),
 		PluginDefVerboseKey:  tr.trps.Verbose,
 		PluginDefLogLevelKey: tr.trps.LogLevel,
@@ -173,6 +180,10 @@ func (tl *TestList) getTaskFuncs(ctx *plaxDsl.Ctx, tr TestRun) ([]*async.TaskFun
 		name := fmt.Sprintf("%s-%s", tr.Name, tr.Version)
 
 		tdr := TestDefRef{
+			TestConstraints: TestConstraints{
+				Labels:   tr.trps.Labels,
+				Priority: tr.trps.Priority,
+			},
 			Name: n,
 		}
 

--- a/cmd/plaxrun/dsl/test_run.go
+++ b/cmd/plaxrun/dsl/test_run.go
@@ -113,7 +113,7 @@ func NewTestRun(ctx *Ctx, trps *TestRunParams) (*TestRun, error) {
 
 	tr.tfs = append(tr.tfs, tfs...)
 
-	if trps.SuiteName != nil {
+	if trps.SuiteName != nil && *trps.SuiteName != "" {
 		testSuite := TestSuiteRef{
 			name:  *trps.SuiteName,
 			tests: trps.Tests,

--- a/cmd/plaxrun/dsl/test_run.go
+++ b/cmd/plaxrun/dsl/test_run.go
@@ -113,12 +113,25 @@ func NewTestRun(ctx *Ctx, trps *TestRunParams) (*TestRun, error) {
 
 	tr.tfs = append(tr.tfs, tfs...)
 
-	tfs, err = trps.Tests.getTaskFuncs(ctx.Ctx, tr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to process tests to execute: %w", err)
-	}
+	if trps.SuiteName != nil {
+		testSuite := TestSuiteRef{
+			name:  *trps.SuiteName,
+			tests: trps.Tests,
+		}
+		tf, err := testSuite.getTaskFunc(ctx.Ctx, tr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process tests to execute: %w", err)
+		}
 
-	tr.tfs = append(tr.tfs, tfs...)
+		tr.tfs = append(tr.tfs, tf)
+	} else {
+		tfs, err = trps.Tests.getTaskFuncs(ctx.Ctx, tr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process tests to execute: %w", err)
+		}
+
+		tr.tfs = append(tr.tfs, tfs...)
+	}
 
 	return &tr, nil
 }
@@ -160,10 +173,13 @@ type TestRunParams struct {
 	Bindings    plaxDsl.Bindings
 	Groups      TestGroupList
 	Tests       TestList
+	SuiteName   *string
 	IncludeDirs IncludeDirList
 	Filename    *string
 	Dir         *string
 	EmitJSON    *bool
 	Verbose     *bool
 	LogLevel    *string
+	Labels      *string
+	Priority    *int
 }

--- a/cmd/plaxrun/dsl/test_suite.go
+++ b/cmd/plaxrun/dsl/test_suite.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dsl
+
+import (
+	"fmt"
+
+	"github.com/Comcast/plax/cmd/plaxrun/async"
+
+	plaxDsl "github.com/Comcast/plax/dsl"
+)
+
+// TestSuiteRef reference
+type TestSuiteRef struct {
+	name  string
+	tests []string
+}
+
+// getTaskFuncs for the TestList
+func (ts *TestSuiteRef) getTaskFunc(ctx *plaxDsl.Ctx, tr TestRun) (*async.TaskFunc, error) {
+	bs, err := (&tr.trps.Bindings).Copy()
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy bindings for test suite %s: %w", ts.name, err)
+	}
+
+	name := fmt.Sprintf("%s-%s", tr.Name, tr.Version)
+	tdr := TestDefRef{
+		TestConstraints: TestConstraints{
+			Labels: tr.trps.Labels,
+		},
+		Name:  ts.name,
+		tests: ts.tests,
+	}
+
+	tf, err := tdr.getTaskFunc(ctx, tr, name, bs)
+	if err != nil {
+		return nil, err
+	}
+
+	return tf, nil
+}

--- a/cmd/plaxrun/main.go
+++ b/cmd/plaxrun/main.go
@@ -54,11 +54,14 @@ func main() {
 			Groups:      dsl.TestGroupList{},
 			Verbose:     flag.Bool("v", true, "Verbosity"),
 			LogLevel:    flag.String("log", "info", "Log level (info, debug, none)"),
+			Labels:      flag.String("labels", "", "Labels for tests to run"),
+			SuiteName:   flag.String("s", "", "Suite name to execute; -t options represent the tests in the suite to execute"),
+			Priority:    flag.Int("p", -1, "Test priority"),
 		}
 		version = flag.Bool("version", false, "Print version and then exit")
 	)
 
-	flag.Var(&trps.Bindings, "p", fmt.Sprintf("Parameter Bindings: %s", trps.Bindings.String()))
+	flag.Var(&trps.Bindings, "b", fmt.Sprintf("Bindings: %s", trps.Bindings.String()))
 	flag.Var(&trps.IncludeDirs, "I", "YAML include directories")
 	flag.Var(&trps.Groups, "g", fmt.Sprintf("Groups to execute: %s", trps.Groups.String()))
 	flag.Var(&trps.Tests, "t", fmt.Sprintf("Tests to execute: %s", trps.Tests.String()))
@@ -71,8 +74,8 @@ func main() {
 		return
 	}
 
-	if len(trps.Groups) == 0 && len(trps.Tests) == 0 {
-		log.Fatal(fmt.Errorf("at least 1 test or test group must be specified"))
+	if len(trps.Groups) == 0 && len(trps.Tests) == 0 && trps.SuiteName == nil {
+		log.Fatal(fmt.Errorf("at least 1 test or test group or test suite must be specified"))
 	}
 
 	ctx := dsl.NewCtx(context.Background())

--- a/cmd/plaxrun/main.go
+++ b/cmd/plaxrun/main.go
@@ -56,12 +56,12 @@ func main() {
 			LogLevel:    flag.String("log", "info", "Log level (info, debug, none)"),
 			Labels:      flag.String("labels", "", "Labels for tests to run"),
 			SuiteName:   flag.String("s", "", "Suite name to execute; -t options represent the tests in the suite to execute"),
-			Priority:    flag.Int("p", -1, "Test priority"),
+			Priority:    flag.Int("priority", -1, "Test priority"),
 		}
 		version = flag.Bool("version", false, "Print version and then exit")
 	)
 
-	flag.Var(&trps.Bindings, "b", fmt.Sprintf("Bindings: %s", trps.Bindings.String()))
+	flag.Var(&trps.Bindings, "p", fmt.Sprintf("Parameter Bindings: %s", trps.Bindings.String()))
 	flag.Var(&trps.IncludeDirs, "I", "YAML include directories")
 	flag.Var(&trps.Groups, "g", fmt.Sprintf("Groups to execute: %s", trps.Groups.String()))
 	flag.Var(&trps.Tests, "t", fmt.Sprintf("Tests to execute: %s", trps.Tests.String()))

--- a/cmd/plaxrun/plugins/plaxos.go
+++ b/cmd/plaxrun/plugins/plaxos.go
@@ -43,6 +43,11 @@ func init() {
 				return nil, err
 			}
 
+			tests, err := def.GetPluginDefTests()
+			if err != nil {
+				return nil, err
+			}
+
 			params, err := def.GetPluginDefParams()
 			if err != nil {
 				return nil, err
@@ -65,7 +70,7 @@ func init() {
 				return nil, err
 			}
 
-			priority, err := def.GetPluginDefPriorty()
+			priority, err := def.GetPluginDefPriority()
 			if err != nil {
 				return nil, err
 			}
@@ -99,6 +104,7 @@ func init() {
 
 			i := plaxInvoke.Invocation{
 				SuiteName:         name,
+				Tests:             tests,
 				Bindings:          bps,
 				Seed:              seed,
 				Verbose:           verbose,

--- a/demos/basic.yaml
+++ b/demos/basic.yaml
@@ -1,3 +1,4 @@
+name: basic
 doc: |
   Just a very pub/recv simple test.
 

--- a/doc/plaxrun.md
+++ b/doc/plaxrun.md
@@ -33,21 +33,29 @@ To get help, run:
 Usage of plaxrun:
   -I value
         YAML include directories
+  -b value
+        Bindings: PARAM=VALUE
   -dir string
         Directory containing test files (default ".")
   -g value
         Groups to execute: Test Group Name
   -json
         Emit JSON test output; instead of JUnit XML
+  -labels string
+        Labels for tests to run
   -log string
         Log level (info, debug, none) (default "info")
-  -p value
-        Parameter Bindings: PARAM=VALUE
+  -p int
+        Test priority (default -1)
   -run string
         Filename for test run specification (default "spec.yaml")
+  -s string
+        Suite name to execute; -t options represent the tests in the suite to execute
   -t value
         Tests to execute: Test Name
   -v    Verbosity (default true)
+  -version
+        Print version and then exit
 ```
 
 Use `-run` to specify the the path to the test run specification file
@@ -66,13 +74,21 @@ To run a single test or set of tests, specify -t:
 
 `plaxrun -run cmd/plaxrun/demos/fullrun.yaml -dir demos -t basic`
 
-*Note:* A combination of `-g` an `-t` is allowed
+To run a set of tests in a test suite, specify `-s` (plaxrun suite name references) and `-t` (plax test name references):
+
+`plaxrun -run cmd/plaxrun/demos/fullrun.yaml -dir demos -s demos -t basic -t test-wait`
+
+*Note:* A combination of `-g` an `-t` is allowed unless `-s` is used
 
 Use `-json` to output a JSON representation of the test results instead of the Junit XML format.  This output includes `test.State` as the key `State` for each test case.
 
-Use `-p 'PARAM=VALUE'` to pass bindings on the command line. You can specify `-p` multiple times:
+Use `-labels` [string] to set the labels filter for tests to run
 
-`plaxrun -run cmd/plaxrun/demos/waitrun.yaml -dir demos -g wait-prompt -p '?WAIT=600' -p '?MARGIN=200'`
+Use `-p` [int] to set the priority of tests to run
+
+Use `-b 'PARAM=VALUE'` to pass bindings on the command line. You can specify `-b` multiple times:
+
+`plaxrun -run cmd/plaxrun/demos/waitrun.yaml -dir demos -g wait-prompt -b '?WAIT=600' -b '?MARGIN=200'`
 
 ### Writing a Specification
 A plaxrun specification is a `.yaml` file which contains the following major elements:

--- a/doc/plaxrun.md
+++ b/doc/plaxrun.md
@@ -88,7 +88,7 @@ Use `-priority` [int] to set the priority of tests to run
 
 Use `-p 'PARAM=VALUE'` to pass bindings on the command line. You can specify `-b` multiple times:
 
-`plaxrun -run cmd/plaxrun/demos/waitrun.yaml -dir demos -g wait-prompt -b '?WAIT=600' -b '?MARGIN=200'`
+`plaxrun -run cmd/plaxrun/demos/waitrun.yaml -dir demos -g wait-prompt -p '?WAIT=600' -p '?MARGIN=200'`
 
 ### Writing a Specification
 A plaxrun specification is a `.yaml` file which contains the following major elements:

--- a/doc/plaxrun.md
+++ b/doc/plaxrun.md
@@ -33,8 +33,6 @@ To get help, run:
 Usage of plaxrun:
   -I value
         YAML include directories
-  -b value
-        Bindings: PARAM=VALUE
   -dir string
         Directory containing test files (default ".")
   -g value
@@ -45,7 +43,9 @@ Usage of plaxrun:
         Labels for tests to run
   -log string
         Log level (info, debug, none) (default "info")
-  -p int
+  -p value
+        Parameter Bindings: PARAM=VALUE
+  -priority int
         Test priority (default -1)
   -run string
         Filename for test run specification (default "spec.yaml")
@@ -84,9 +84,9 @@ Use `-json` to output a JSON representation of the test results instead of the J
 
 Use `-labels` [string] to set the labels filter for tests to run
 
-Use `-p` [int] to set the priority of tests to run
+Use `-priority` [int] to set the priority of tests to run
 
-Use `-b 'PARAM=VALUE'` to pass bindings on the command line. You can specify `-b` multiple times:
+Use `-p 'PARAM=VALUE'` to pass bindings on the command line. You can specify `-b` multiple times:
 
 `plaxrun -run cmd/plaxrun/demos/waitrun.yaml -dir demos -g wait-prompt -b '?WAIT=600' -b '?MARGIN=200'`
 

--- a/dsl/specs_test.go
+++ b/dsl/specs_test.go
@@ -76,7 +76,7 @@ func TestSpecs(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !tst.Wanted(ctx, -1, []string{"selftest"}) {
+			if !tst.Wanted(ctx, -1, []string{"selftest"}, []string{}) {
 				return
 			}
 

--- a/dsl/test_test.go
+++ b/dsl/test_test.go
@@ -33,17 +33,17 @@ func TestWanted(t *testing.T) {
 	tst := NewTest(ctx, "a", nil)
 	tst.Priority = 42
 	t.Run("priority-negative", func(t *testing.T) {
-		if !tst.Wanted(ctx, -1, nil) {
+		if !tst.Wanted(ctx, -1, nil, nil) {
 			t.Fatal(-1)
 		}
 	})
 	t.Run("priority-high", func(t *testing.T) {
-		if !tst.Wanted(ctx, 52, nil) {
+		if !tst.Wanted(ctx, 52, nil, nil) {
 			t.Fatal(52)
 		}
 	})
 	t.Run("priority-low", func(t *testing.T) {
-		if tst.Wanted(ctx, 1, nil) {
+		if tst.Wanted(ctx, 1, nil, nil) {
 			t.Fatal(1)
 		}
 	})


### PR DESCRIPTION
To enable plaxrun to execute a subset of tests in a plax test suite the following changes were required:

- main.go, test_run.go, test_def.go, test_suite.go: Add `-s` flag to plaxrun to name the test suite reference;  `-t` is the set of test in the suite to run; update logic to use the `-s` and `-t` flags in concert
- main.go: Add `-p` for priority filtering from plaxrun
- main.go, test_constraints.go: Add `-labels` for label filtering from plaxrun and change labels to a string
- plax_plugin.go, plaxos.go: Update the plaxrun plax plugin definition to include the list of tests that are wanted
- dsl/test.go, invoke.go, dsl/test_test.go, dsl/specs_test.go: Update Wanted logic to include the check for the list of tests if provided
- manual.md: Update to plaxrun manual