### PR TITLE
Fix HTTP client polling (unit test); closes #45

### DIFF
--- a/chans/httpclient/httpclient_test.go
+++ b/chans/httpclient/httpclient_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,6 +38,8 @@ func TestDocs(t *testing.T) {
 // TestHTTPRequestPolling check that a HTTPRequest channel actually
 // makes multiple requests when a PollInterval is given.
 func TestHTTPRequestPolling(t *testing.T) {
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+
 	var (
 		ctx      = dsl.NewCtx(context.Background())
 		interval = 50 * time.Millisecond // PollInterval
@@ -102,12 +105,12 @@ func TestHTTPRequestPolling(t *testing.T) {
 			t.Fatal("ctx done")
 		case <-to.C:
 			t.Fatal("timeout")
-		case <-ch:
+		case msg := <-ch:
 			// We got a message.
 			if 0 < i {
 				// All messages after the first one.
 				if elapsed := time.Now().Sub(then); elapsed < min {
-					t.Fatalf("too fast: %v", elapsed)
+					t.Fatalf("too fast: %v, i=%d msg=%s", elapsed, i, dsl.JSON(msg))
 				}
 				// The timer in the 'select' will
 				// complain about a slow poll.

--- a/doc/chan_httpclient.md
+++ b/doc/chan_httpclient.md
@@ -42,6 +42,10 @@ Currently this channel doesn't have any configuration.
     1. `pollInterval` (string) not zero, will cause this channel to
         repeated the HTTP request at this interval.
         
+        The timer starts after the last request has completed.
+        (Previously the timer fired requests at this interval
+        regardless of the latency of the previous HTTP request(s).)
+        
         Value should be a string that time.ParseDuration can parse.
 
     1. `terminate` (string) not zero, should be the Id of a previous polling


### PR DESCRIPTION
Changed the polling implementation to start the timer
after the last request has completed.  That's probably the
right thing to do.

I don't know if this commit really fixes the test. I guess we'll
see.
