### PR TITLE
Command channel (cmd) exit code topic handling

### DIFF
--- a/chans/shell/cmd.go
+++ b/chans/shell/cmd.go
@@ -24,6 +24,7 @@ package shell
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/Comcast/plax/dsl"
@@ -107,6 +108,9 @@ func (c *CmdChan) Open(ctx *dsl.Ctx) error {
 				out("stdout", line)
 			case line := <-c.p.Stderr:
 				out("stderr", line)
+			case exitCode := <-c.p.ExitCode:
+				out("exit", strconv.Itoa(exitCode))
+				return
 			}
 		}
 	}()

--- a/demos/shell.yaml
+++ b/demos/shell.yaml
@@ -9,6 +9,7 @@ spec:
     phase1:
       steps:
         - pub:
+            chan: mother
             payload:
               make:
                 name: shell
@@ -58,3 +59,42 @@ spec:
             serialization: string
             regexp: |
               I like good queso\.
+        - pub:
+            doc: |
+              Exit the shell with an exit code 1
+            serialization:
+            payload: |
+              exit 1
+        - recv:
+            doc: |
+              Handle the shell exit code 1
+            topic: exit
+            regexp: 1
+        - goto: phase2
+    phase2:
+      steps:
+        - pub:
+            chan: mother
+            payload:
+              make:
+                name: shell2
+                type: cmd
+                config:
+                  command: bash
+        - recv:
+            chan: mother
+            pattern:
+              success: true
+        - pub:
+            chan: shell2
+            doc: |
+              Exit the shell with an exit code 0
+            serialization:
+            payload: |
+              exit 0
+        - recv:
+            chan: shell2
+            doc: |
+              Handle the shell exit code 0
+            topic: exit
+            regexp: 0


### PR DESCRIPTION
Added support to handle the exit code from the command channel (cmd):

1. Updated the cmd channel docs (chan_cmd.md) to describe the supported recv topics, including the new "exit" topic
2. Updated process.go to add a go routine to wait on process exit and return the ProcessState.ExitCode() over the exitCode go chan
3. Updated the cmd.go channel to handle the exitCode go chan and send an exit code message (string representation of the command process exit code) over the "exit" topic