### PR TITLE
Fix -p key=str parsing bug; closes #71

### DIFF
--- a/dsl/bindings_test.go
+++ b/dsl/bindings_test.go
@@ -164,3 +164,69 @@ func TestSubstituteOnce(t *testing.T) {
 		}
 	})
 }
+
+func TestBindingsSet(t *testing.T) {
+	bs := NewBindings()
+	check := func(err error, key, want string) {
+		if err != nil {
+			t.Fatalf("key %s -> <%v> != %s", key, err, want)
+		}
+		got, have := bs[key]
+		if !have {
+			t.Fatalf("key %s -> %s != %s", key, got, want)
+		}
+	}
+
+	err := bs.Set(`like="tacos"`)
+	check(err, "like", "tacos")
+
+	err = bs.Set(`like=tacos`)
+	check(err, "like", "tacos")
+
+	if err = bs.Set(`like=42`); err != nil {
+		t.Fatal(err)
+	} else {
+		x, have := bs["like"]
+		if !have {
+			t.Fatal("like")
+		}
+		switch vv := x.(type) {
+		case float64:
+			if vv != 42 {
+				t.Fatal(vv)
+			}
+		default:
+			t.Fatalf("%T: %v", x, x)
+		}
+	}
+
+	if err = bs.Set(`like={"want":"chips"}`); err != nil {
+		t.Fatal(err)
+	} else {
+		x, have := bs["like"]
+		if !have {
+			t.Fatal("like")
+		}
+		switch vv := x.(type) {
+		case map[string]interface{}:
+			x, have := vv["want"]
+			if !have {
+				t.Fatal(err)
+			}
+			switch vv := x.(type) {
+			case string:
+				if vv != "chips" {
+					t.Fatal(vv)
+				}
+			default:
+				t.Fatalf("%T: %v", x, x)
+			}
+		default:
+			t.Fatalf("%T: %v", x, x)
+		}
+	}
+
+	if err = bs.Set(`liketacos`); err == nil {
+		t.Fatal("should have complained")
+	}
+}


### PR DESCRIPTION
If the `value` in `key=value` didn't JSON-unmarshal, the entire `key=value` was used for the value.  This PR fixes that, which we currently need for backwards compatibility. I hope this PR doesn't break other things!