### PR TITLE
Candidate fix for lack of deserialization

### DIFF
--- a/cmd/plaxrun/dsl/test_param.go
+++ b/cmd/plaxrun/dsl/test_param.go
@@ -205,7 +205,9 @@ func (tpb *TestParamBinding) run(ctx *plaxDsl.Ctx, key string, bs *plaxDsl.Bindi
 		k := match[1]
 		v := match[2]
 		ctx.Logdf("Binding %s=%s", k, v)
-		bs.SetKeyValue(k, v)
+
+		// We might need to JSON-deserialize the value.
+		bs.Set(fmt.Sprintf("%s=%s", k, v))
 	}
 
 	return nil


### PR DESCRIPTION
When using a cmd to generate bindings, we sometimes need to
deserialize the emitted values.

Needs a test case or two.