### PR TITLE
Plaxrun needs to pass the commands line labels to each individual test

### DIFF
--- a/cmd/plaxrun/demos/demos.yaml
+++ b/cmd/plaxrun/demos/demos.yaml
@@ -1,0 +1,11 @@
+name: demos
+version: 0.0.1
+
+tests:
+  demos:
+    path: demos
+
+groups:
+  demos:
+    tests:        
+      - name: demos

--- a/cmd/plaxrun/dsl/test_def.go
+++ b/cmd/plaxrun/dsl/test_def.go
@@ -109,17 +109,21 @@ func (tdr TestDefRef) getTaskFunc(ctx *plaxDsl.Ctx, tr TestRun, name string, bs 
 		priority = *tdr.Priority
 	}
 
+	// Empty labels
 	labelArr := make([]string, 0)
 
 	if tr.trps.Labels != nil {
+		// Labels from command line
 		labelArr = strings.Split(*tr.trps.Labels, ",")
 	}
 
 	if tdr.Labels != nil {
+		// Labels from test definition
 		arr := strings.Split(*tdr.Labels, ",")
 		labelArr = append(labelArr, arr...)
 	}
 
+	// All labels from command line and test definition
 	labels := strings.Join(labelArr, ",")
 
 	def := PluginDef{

--- a/cmd/plaxrun/dsl/test_def.go
+++ b/cmd/plaxrun/dsl/test_def.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/Comcast/plax/cmd/plaxrun/async"
 	plaxDsl "github.com/Comcast/plax/dsl"
@@ -108,10 +109,18 @@ func (tdr TestDefRef) getTaskFunc(ctx *plaxDsl.Ctx, tr TestRun, name string, bs 
 		priority = *tdr.Priority
 	}
 
-	labels := ""
-	if tdr.Labels != nil {
-		labels = *tdr.Labels
+	labelArr := make([]string, 0)
+
+	if tr.trps.Labels != nil {
+		labelArr = strings.Split(*tr.trps.Labels, ",")
 	}
+
+	if tdr.Labels != nil {
+		arr := strings.Split(*tdr.Labels, ",")
+		labelArr = append(labelArr, arr...)
+	}
+
+	labels := strings.Join(labelArr, ",")
 
 	def := PluginDef{
 		PluginDefNameKey:        name,


### PR DESCRIPTION
Plaxrun now passes the command line -labels  to each individual plax test execution.