### PR TITLE
standardize on plaxrun_report_rp for Report Portal plugin name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,8 +56,8 @@ builds:
       - goos: darwin
         goarch: arm64
   - main: cmd/plaxrun/plugins/report/rp/main.go
-    id: plaxrun_report_portal
-    binary: plaxrun_report_portal
+    id: plaxrun_report_rp
+    binary: plaxrun_report_rp
     goos:
       - linux
       - darwin

--- a/cmd/plaxrun/plugins/report/rp/main.go
+++ b/cmd/plaxrun/plugins/report/rp/main.go
@@ -36,7 +36,7 @@ var (
 
 // Config the plugin
 func (rpi *ReportPortalImpl) Config(cfgb []byte) error {
-	logger.Debug("plaxrun_report_portal: config called")
+	logger.Debug("plaxrun_report_rp: config called")
 
 	err := json.Unmarshal(cfgb, &rpi.config)
 	if err != nil {
@@ -55,13 +55,13 @@ func (rpi *ReportPortalImpl) Config(cfgb []byte) error {
 			
 			return nil
 		})
-		logger.Debug("plaxrun_report_portal: config done")
+		logger.Debug("plaxrun_report_rp: config done")
 	return nil
 }
 
 // Generate the test report
 func (rpi *ReportPortalImpl) Generate(tr *report.TestReport) error {
-	logger.Debug("plaxrun_report_portal: generate called")
+	logger.Debug("plaxrun_report_rp: generate called")
 	client := rp.NewClient(rpi.config.Hostname, rpi.config.Project, rpi.config.Token)
 
 	launchUUID := uuid.New()
@@ -148,7 +148,7 @@ func (rpi *ReportPortalImpl) Generate(tr *report.TestReport) error {
 }
 
 func main() {
-	logger.Debug("plaxrun_report_portal: start")
+	logger.Debug("plaxrun_report_rp: start")
 
 	// pluginMap is the map of plugins we can dispense.
 	var pluginMap = map[string]plugin.Plugin{
@@ -160,5 +160,5 @@ func main() {
 		Plugins:         pluginMap,
 	})
 
-	logger.Debug("plaxrun_report_portal: stop")
+	logger.Debug("plaxrun_report_rp: stop")
 }


### PR DESCRIPTION
This PR addresses runtime errors when trying to execute the Report Portal plugin against plax v0.8.22.

```
2021-12-07T20:52:19.374Z [DEBUG] plugin: starting plugin: path=plaxrun_report_rp args=[plaxrun_report_rp]
2021/12/07 20:52:19 > exec: "plaxrun_report_rp": executable file not found in $PATH
```

The binary as packaged in https://github.com/Comcast/plax/releases/download/v0.8.22/plax_0.8.22_Linux_x86_64.tar.gz is `plax_0.8.22_Linux_x86_64/plaxrun_report_portal`

Aligning the binary name, directory, and log messages should resolve this issue.