### PR TITLE
Octane plugin upgrade

### DIFF
--- a/doc/octane_plugin.md
+++ b/doc/octane_plugin.md
@@ -32,6 +32,8 @@ reports:
       app_module_id: 485024
       test_fields:     // optional
         Framework: plax
+      environment:     // optional
+        AUT Env: {ENVIRONMENT}
 ```
 
 Notes:


### PR DESCRIPTION
Description:
This PR adds environment tagging functionality to the Octane plugin code. 

Sample usage:

I added config (referred in the doc/octane_plugin.md below) to cmd/plaxrun/demos/waitrun.yaml and ran the command - plaxrun -run cmd/plaxrun/demos/waitrun.yaml -dir demos -g wait-no-prompt -json

Octane plugin - console log:
```
<test_result>
 <product_areas>
  <product_area_ref id="123456"></product_area_ref>
 </product_areas>
 <environment>
  <taxonomy type="AUT Env" value="integration"> </taxonomy>
 </environment>
 <test_runs>
  <test_run name="test-wait waitrun-0.0.1:wait-no-prompt:wait" duration="606" status="Failed" started="1632173133000">
   <test_fields>
    <test_field type="Framework" value="plax"></test_field>
   </test_fields>
   <error>Broken: Err: Broken: phase phase1: Broken: step 5: Broken: Javascript problem: failure: too slow: 605</error>
  </test_run>
 </test_runs>
</test_result>
```
Equivalent Plax console log:
```
{
  "name": "waitrun",
  "version": "0.0.1",
  "testsuite": [
    {
      "name": "waitrun-0.0.1:wait-no-prompt:wait",
      "tests": 1,
      "passed": 0,
      "skipped": 0,
      "failures": 0,
      "errors": 1,
      "testcase": [
        {
          "name": "test-wait",
          "file": "/Users/smudig200/Documents/comcastgit/octane_plugin/plax/demos/test-wait.yaml",
          "status": "error",
          "time": 606178000,
          "started": "2021-09-20T21:25:33.730331Z",
          "message": "Broken: Err: Broken: phase phase1: Broken: step 5: Broken: Javascript problem: failure: too slow: 605"
        }
      ],
      "timestamp": "2021-09-20T21:25:33.728889Z",
      "time": 607622000
    }
  ],
  "tests": 1,
  "passed": 0,
  "skipped": 0,
  "failures": 0,
  "errors": 1,
  "timestamp": "2021-09-20T21:25:33.728736Z",
  "time": 607783000
}
```