### PR TITLE
Added support for darwin-arm64 in goreleaser and updated archive naming.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,8 +17,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: darwin
-        goarch: arm64
   - main: cmd/plaxrun/main.go
     id: plaxrun
     binary: plaxrun
@@ -28,8 +26,6 @@ builds:
       - windows
     ignore:
       - goos: windows
-        goarch: arm64
-      - goos: darwin
         goarch: arm64
   - main: cmd/plaxrun/plugins/report/stdout/main.go
     id: plaxrun_report_stdout
@@ -41,8 +37,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: darwin
-        goarch: arm64
   - main: cmd/plaxrun/plugins/report/octane/main.go
     id: plaxrun_report_octane
     binary: plaxrun_report_octane
@@ -52,8 +46,6 @@ builds:
       - windows
     ignore:
       - goos: windows
-        goarch: arm64
-      - goos: darwin
         goarch: arm64
   - main: cmd/plaxrun/plugins/report/rp/main.go
     id: plaxrun_report_rp
@@ -65,8 +57,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: darwin
-        goarch: arm64
   - main: cmd/yamlincl/main.go
     id: yamlincl
     binary: yamlincl
@@ -77,15 +67,15 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: darwin
-        goarch: arm64
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
Added name template to fix deprecated functionality with archive naming.
Removed ignores for darwin arm64 to support M1 Mac