### PR TITLE
Bugfix issue168

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
   - main: cmd/plax/main.go
     id: plax
     binary: plax
+    buildmode: 'c-shared'
     goos:
       - linux
       - darwin
@@ -20,6 +21,7 @@ builds:
   - main: cmd/plaxrun/main.go
     id: plaxrun
     binary: plaxrun
+    buildmode: 'c-shared'
     goos:
       - linux
       - darwin
@@ -30,6 +32,7 @@ builds:
   - main: cmd/plaxrun/plugins/report/stdout/main.go
     id: plaxrun_report_stdout
     binary: plaxrun_report_stdout
+    buildmode: 'c-shared'
     goos:
       - linux
       - darwin
@@ -40,6 +43,7 @@ builds:
   - main: cmd/plaxrun/plugins/report/octane/main.go
     id: plaxrun_report_octane
     binary: plaxrun_report_octane
+    buildmode: 'c-shared'
     goos:
       - linux
       - darwin
@@ -50,6 +54,7 @@ builds:
   - main: cmd/plaxrun/plugins/report/rp/main.go
     id: plaxrun_report_rp
     binary: plaxrun_report_rp
+    buildmode: 'c-shared'
     goos:
       - linux
       - darwin
@@ -60,6 +65,7 @@ builds:
   - main: cmd/yamlincl/main.go
     id: yamlincl
     binary: yamlincl
+    buildmode: 'c-shared'
     goos:
       - linux
       - darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 release:
   github:
-    owner: Comcast
+    owner: hemanjayam
     name: plax
 before:
   hooks:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: 'c-shared'
   - main: cmd/plaxrun/main.go
     id: plaxrun
     binary: plaxrun
@@ -28,7 +27,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: 'c-shared'
   - main: cmd/plaxrun/plugins/report/stdout/main.go
     id: plaxrun_report_stdout
     binary: plaxrun_report_stdout
@@ -39,7 +37,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: 'c-shared'
   - main: cmd/plaxrun/plugins/report/octane/main.go
     id: plaxrun_report_octane
     binary: plaxrun_report_octane
@@ -50,7 +47,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: 'c-shared'
   - main: cmd/plaxrun/plugins/report/rp/main.go
     id: plaxrun_report_rp
     binary: plaxrun_report_rp
@@ -61,7 +57,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: 'c-shared'
   - main: cmd/yamlincl/main.go
     id: yamlincl
     binary: yamlincl
@@ -72,7 +67,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-   buildmode: 'c-shared'
 archives:
   - name_template: >-
       {{- .ProjectName }}_

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+    buildmode: c-shared
   - main: cmd/plaxrun/main.go
     id: plaxrun
     binary: plaxrun
@@ -27,6 +28,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+    buildmode: c-shared
   - main: cmd/plaxrun/plugins/report/stdout/main.go
     id: plaxrun_report_stdout
     binary: plaxrun_report_stdout
@@ -37,6 +39,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+    buildmode: c-shared
   - main: cmd/plaxrun/plugins/report/octane/main.go
     id: plaxrun_report_octane
     binary: plaxrun_report_octane
@@ -47,6 +50,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+    buildmode: c-shared
   - main: cmd/plaxrun/plugins/report/rp/main.go
     id: plaxrun_report_rp
     binary: plaxrun_report_rp
@@ -57,6 +61,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+    buildmode: c-shared
   - main: cmd/yamlincl/main.go
     id: yamlincl
     binary: yamlincl
@@ -67,6 +72,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+   buildmode: c-shared
 archives:
   - name_template: >-
       {{- .ProjectName }}_

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,8 @@ builds:
   - main: cmd/plax/main.go
     id: plax
     binary: plax
-    buildmode: 'c-shared'
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -21,7 +22,8 @@ builds:
   - main: cmd/plaxrun/main.go
     id: plaxrun
     binary: plaxrun
-    buildmode: 'c-shared'
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -32,7 +34,8 @@ builds:
   - main: cmd/plaxrun/plugins/report/stdout/main.go
     id: plaxrun_report_stdout
     binary: plaxrun_report_stdout
-    buildmode: 'c-shared'
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -43,7 +46,8 @@ builds:
   - main: cmd/plaxrun/plugins/report/octane/main.go
     id: plaxrun_report_octane
     binary: plaxrun_report_octane
-    buildmode: 'c-shared'
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -54,7 +58,8 @@ builds:
   - main: cmd/plaxrun/plugins/report/rp/main.go
     id: plaxrun_report_rp
     binary: plaxrun_report_rp
-    buildmode: 'c-shared'
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -65,7 +70,8 @@ builds:
   - main: cmd/yamlincl/main.go
     id: yamlincl
     binary: yamlincl
-    buildmode: 'c-shared'
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: c-shared
+    buildmode: 'c-shared'
   - main: cmd/plaxrun/main.go
     id: plaxrun
     binary: plaxrun
@@ -28,7 +28,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: c-shared
+    buildmode: 'c-shared'
   - main: cmd/plaxrun/plugins/report/stdout/main.go
     id: plaxrun_report_stdout
     binary: plaxrun_report_stdout
@@ -39,7 +39,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: c-shared
+    buildmode: 'c-shared'
   - main: cmd/plaxrun/plugins/report/octane/main.go
     id: plaxrun_report_octane
     binary: plaxrun_report_octane
@@ -50,7 +50,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: c-shared
+    buildmode: 'c-shared'
   - main: cmd/plaxrun/plugins/report/rp/main.go
     id: plaxrun_report_rp
     binary: plaxrun_report_rp
@@ -61,7 +61,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-    buildmode: c-shared
+    buildmode: 'c-shared'
   - main: cmd/yamlincl/main.go
     id: yamlincl
     binary: yamlincl
@@ -72,7 +72,7 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-   buildmode: c-shared
+   buildmode: 'c-shared'
 archives:
   - name_template: >-
       {{- .ProjectName }}_

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,8 +10,7 @@ builds:
   - main: cmd/plax/main.go
     id: plax
     binary: plax
-    env:
-      - CGO_ENABLED=0
+    buildmode: 'c-shared'
     goos:
       - linux
       - darwin
@@ -22,8 +21,7 @@ builds:
   - main: cmd/plaxrun/main.go
     id: plaxrun
     binary: plaxrun
-    env:
-      - CGO_ENABLED=0
+    buildmode: 'c-shared'
     goos:
       - linux
       - darwin
@@ -34,8 +32,6 @@ builds:
   - main: cmd/plaxrun/plugins/report/stdout/main.go
     id: plaxrun_report_stdout
     binary: plaxrun_report_stdout
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -46,8 +42,6 @@ builds:
   - main: cmd/plaxrun/plugins/report/octane/main.go
     id: plaxrun_report_octane
     binary: plaxrun_report_octane
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -58,8 +52,6 @@ builds:
   - main: cmd/plaxrun/plugins/report/rp/main.go
     id: plaxrun_report_rp
     binary: plaxrun_report_rp
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -70,8 +62,6 @@ builds:
   - main: cmd/yamlincl/main.go
     id: yamlincl
     binary: yamlincl
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
       - darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 release:
   github:
-    owner: hemanjayam
+    owner: Comcast
     name: plax
 before:
   hooks:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,8 @@ builds:
   - main: cmd/plax/main.go
     id: plax
     binary: plax
-    buildmode: 'c-shared'
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -21,7 +22,8 @@ builds:
   - main: cmd/plaxrun/main.go
     id: plaxrun
     binary: plaxrun
-    buildmode: 'c-shared'
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -32,6 +34,8 @@ builds:
   - main: cmd/plaxrun/plugins/report/stdout/main.go
     id: plaxrun_report_stdout
     binary: plaxrun_report_stdout
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -42,6 +46,8 @@ builds:
   - main: cmd/plaxrun/plugins/report/octane/main.go
     id: plaxrun_report_octane
     binary: plaxrun_report_octane
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -52,6 +58,8 @@ builds:
   - main: cmd/plaxrun/plugins/report/rp/main.go
     id: plaxrun_report_rp
     binary: plaxrun_report_rp
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -62,6 +70,8 @@ builds:
   - main: cmd/yamlincl/main.go
     id: yamlincl
     binary: yamlincl
+    env:
+      - CGO_ENABLED=0
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ clean:
 
 .PHONY: dist
 dist: clean
-	goreleaser release --skip-publish --rm-dist
+	goreleaser release --skip=publish --clean
 
 .PHONY: release
 release: clean
-	goreleaser release --rm-dist
+	goreleaser release --clean
 
 # A demonstratio of using a Go plug-in to load a MySQL driver at
 # runtime for use in a Plax test that uses a SQL channel to talk to


### PR DESCRIPTION
To fix error plax: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by plax) and  plax: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by plax). Setting CGO_ENABLED=0 in goreleaser to disable calling C code

Also updated --skip-publish to --skip=publish and  --rm-dist to --clean as they are getting deprecated, check https://goreleaser.com/deprecations#-skip and  https://goreleaser.com/deprecations#-rm-dist  for more details