### PR TITLE
PLATX-5892: Fix MQTT ClientOptions initialization for paho.mqtt.golan…

### DIFF
--- a/chans/mqtt/mqtt.go
+++ b/chans/mqtt/mqtt.go
@@ -239,7 +239,7 @@ func dur(ms int64) time.Duration {
 
 // Opts constructions an mq.ClientOptions.
 func (o *MQTTOpts) Opts(ctx *dsl.Ctx) (*mq.ClientOptions, error) {
-	opts := mq.ClientOptions{}
+	opts := mq.NewClientOptions()
 
 	ctx.Logf("MQTT Opts broker: %s", o.BrokerURL)
 	opts.AddBroker(o.BrokerURL)
@@ -337,7 +337,7 @@ func (o *MQTTOpts) Opts(ctx *dsl.Ctx) (*mq.ClientOptions, error) {
 		ctx.Logf("MQTT %s connection lost", o.ClientID)
 	}
 
-	return &opts, nil
+	return opts, nil
 }
 
 func (c *MQTT) Kind() dsl.ChanKind {


### PR DESCRIPTION
…g v1.5.0+

Use NewClientOptions() constructor instead of zero-value struct to properly initialize internal fields (Dialer, WebsocketOptions, HTTPHeaders) required by paho.mqtt.golang v1.5.0+.

Changes:
- Line 242: Use mq.NewClientOptions() instead of mq.ClientOptions{}
- Line 340: Return opts directly (NewClientOptions already returns pointer)

Fixes nil pointer panic in SetConnectTimeout() when using paho.mqtt.golang v1.5.1.

Root cause: paho v1.5.0+ added Dialer field that SetConnectTimeout() accesses. Zero-value struct leaves Dialer=nil causing segfault. NewClientOptions() properly initializes all required fields.

Tested with IoTTest xhf-onboarding suite using paho.mqtt.golang v1.5.1.